### PR TITLE
🔧 Fix GitHub Actions: Update upload-artifact to v4

### DIFF
--- a/.github/workflows/deploy-hf-final.yml
+++ b/.github/workflows/deploy-hf-final.yml
@@ -285,7 +285,7 @@ jobs:
         cat deployment_summary.md
 
     - name: Upload deployment artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: hf-deployment-files
         path: |


### PR DESCRIPTION
### **User description**
- Fix deprecated actions/upload-artifact@v3 error
- Update to actions/upload-artifact@v4 (latest stable)
- Resolves GitHub Actions workflow failure


___

### **PR Type**
Other


___

### **Description**
• Update GitHub Actions upload-artifact from v3 to v4
• Fix deprecated action version in deployment workflow


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>deploy-hf-final.yml</strong><dd><code>Update upload-artifact action to v4</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/deploy-hf-final.yml

• Updated <code>actions/upload-artifact</code> from v3 to v4<br> • Fixed deprecated <br>action version in deployment workflow


</details>


  </td>
  <td><a href="https://github.com/Minatoz997/OpenHands-Backend/pull/34/files#diff-ac8194fd3c59979313193d08f139428acc47be6fceb93f91c1e32d90dc019e22">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>